### PR TITLE
esp32-build: use non deprecated mbedtls sha256 functions

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -30,12 +30,9 @@ ByteVector sha256(const ByteVector &buf) {
     uint8_t digest[SHA256_LEN];
     mbedtls_sha256_context ctx;
     mbedtls_sha256_init(&ctx);
-    int ret = mbedtls_sha256_starts_ret(&ctx, 0);
-    assert(!ret);
-    ret = mbedtls_sha256_update_ret(&ctx, &buf[0], buf.size());                         \
-    assert(!ret);
-    ret = mbedtls_sha256_finish_ret(&ctx, digest);
-    assert(!ret);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, &buf[0], buf.size());
+    mbedtls_sha256_finish(&ctx, digest);
     mbedtls_sha256_free(&ctx);
 
     return ByteVector(digest, digest + SHA256_LEN);


### PR DESCRIPTION
The sha256 functions in use before this changes are deprecated and are no longer supported as of esp idf 5.x

This change is backwards compatible and works on esp idf 4.4.3, 4.4.4 and 5.0