### PR TITLE
esp32-build: Decoder to use std::allocator which prefers SPI-/PSRAM

### DIFF
--- a/src/fountain-decoder.cpp
+++ b/src/fountain-decoder.cpp
@@ -31,7 +31,7 @@ FountainDecoder::Part::Part(PartIndexes& indexes, ByteVector& data)
 {
 }
 
-const ByteVector FountainDecoder::join_fragments(const vector<ByteVector>& fragments, size_t message_len) {
+const ByteVector FountainDecoder::join_fragments(const ByteVectorVector& fragments, size_t message_len) {
     auto message = join(fragments);
     return take_first(message, message_len);
 }
@@ -90,7 +90,7 @@ void FountainDecoder::process_queue_item() {
 
 void FountainDecoder::reduce_mixed_by(const Part& p) {
     // Reduce all the current mixed parts by the given part
-    vector<Part> reduced_parts;
+    PartVector reduced_parts;
     for(auto i = _mixed_parts.begin(); i != _mixed_parts.end(); i++) {
         reduced_parts.push_back(reduce_part_by_part(i->second, p));
     }
@@ -136,14 +136,14 @@ void FountainDecoder::process_simple_part(Part& p) {
     // If we've received all the parts
     if(received_part_indexes_ == _expected_part_indexes) {
         // Reassemble the message from its fragments
-        vector<Part> sorted_parts;
+        PartVector sorted_parts;
         transform(_simple_parts.begin(), _simple_parts.end(), back_inserter(sorted_parts), [&](auto elem) { return elem.second; });
         sort(sorted_parts.begin(), sorted_parts.end(),
             [](const Part& a, const Part& b) -> bool {
                 return a.index() < b.index();
             }
         );
-        vector<ByteVector> fragments;
+        ByteVectorVector fragments;
         transform(sorted_parts.begin(), sorted_parts.end(), back_inserter(fragments), [&](auto part) { return part.data(); });
         auto message = join_fragments(fragments, *_expected_message_len);
 

--- a/src/fountain-decoder.hpp
+++ b/src/fountain-decoder.hpp
@@ -10,6 +10,7 @@
 
 #include "utils.hpp"
 #include "fountain-encoder.hpp"
+#include "psram-allocator.hpp"
 #include <map>
 #include <exception>
 #include <deque>
@@ -42,7 +43,7 @@ public:
     bool receive_part(FountainEncoder::Part& encoder_part);
 
     // Join all the fragments of a message together, throwing away any padding
-    static const ByteVector join_fragments(const std::vector<ByteVector>& fragments, size_t message_len);
+    static const ByteVector join_fragments(const ByteVectorVector& fragments, size_t message_len);
 
 private:
     class Part {
@@ -66,7 +67,8 @@ private:
 
     Result result_;
 
-    typedef std::map<PartIndexes, Part> PartDict;
+    typedef std::vector<Part, PSRAMAllocator<Part>> PartVector;
+    typedef std::map<PartIndexes, Part, std::less<PartIndexes>, PSRAMAllocator<std::pair<const PartIndexes, Part>>> PartDict;
 
     std::optional<PartIndexes> _expected_part_indexes;
     std::optional<size_t> _expected_fragment_len;
@@ -75,7 +77,7 @@ private:
 
     PartDict _simple_parts;
     PartDict _mixed_parts;
-    std::deque<Part> _queued_parts;
+    std::deque<Part, PSRAMAllocator<Part>> _queued_parts;
 
     void enqueue(const Part &p);
     void enqueue(Part &&p);

--- a/src/fountain-encoder.cpp
+++ b/src/fountain-encoder.cpp
@@ -32,9 +32,9 @@ size_t FountainEncoder::find_nominal_fragment_length(size_t message_len, size_t 
     return *fragment_len;
 }
 
-vector<ByteVector> FountainEncoder::partition_message(const ByteVector &message, size_t fragment_len) {
+ByteVectorVector FountainEncoder::partition_message(const ByteVector &message, size_t fragment_len) {
     auto remaining = message;
-    vector<ByteVector> fragments;
+    ByteVectorVector fragments;
     while(!remaining.empty()) {
         auto a = split(remaining, fragment_len);
         auto fragment = a.first;

--- a/src/fountain-encoder.hpp
+++ b/src/fountain-encoder.hpp
@@ -51,7 +51,7 @@ public:
     FountainEncoder(const ByteVector& message, size_t max_fragment_len, uint32_t first_seq_num = 0, size_t min_fragment_len = 10);
     
     static size_t find_nominal_fragment_length(size_t message_len, size_t min_fragment_len, size_t max_fragment_len);
-    static std::vector<ByteVector> partition_message(const ByteVector &message, size_t fragment_len);
+    static ByteVectorVector partition_message(const ByteVector &message, size_t fragment_len);
 
     uint32_t seq_num() const { return seq_num_; }
     const PartIndexes& last_part_indexes() const { return last_part_indexes_; }
@@ -70,7 +70,7 @@ private:
     size_t message_len_;
     uint32_t checksum_;
     size_t fragment_len_;
-    std::vector<ByteVector> fragments_;
+    ByteVectorVector fragments_;
     uint32_t seq_num_;
     PartIndexes last_part_indexes_;
 

--- a/src/fountain-utils.cpp
+++ b/src/fountain-utils.cpp
@@ -22,12 +22,12 @@ size_t choose_degree(size_t seq_len, Xoshiro256& rng) {
     return degree_chooser.next([&]() { return rng.next_double(); }) + 1;
 }
 
-set<size_t> choose_fragments(uint32_t seq_num, size_t seq_len, uint32_t checksum) {
+PartIndexes choose_fragments(uint32_t seq_num, size_t seq_len, uint32_t checksum) {
     // The first `seq_len` parts are the "pure" fragments, not mixed with any
     // others. This means that if you only generate the first `seq_len` parts,
     // then you have all the parts you need to decode the message.
     if(seq_num <= seq_len) {
-        return set<size_t>({seq_num - 1});
+        return PartIndexes({seq_num - 1});
     } else {
         auto seed = join(vector({int_to_bytes(seq_num), int_to_bytes(checksum)}));
         auto rng = Xoshiro256(seed);
@@ -36,7 +36,7 @@ set<size_t> choose_fragments(uint32_t seq_num, size_t seq_len, uint32_t checksum
         indexes.reserve(seq_len);
         for(int i = 0; i < seq_len; i++) { indexes.push_back(i); }
         auto shuffled_indexes = shuffled(indexes, rng);
-        return set<size_t>(shuffled_indexes.begin(), shuffled_indexes.begin() + degree);
+        return PartIndexes(shuffled_indexes.begin(), shuffled_indexes.begin() + degree);
     }
 }
 

--- a/src/fountain-utils.hpp
+++ b/src/fountain-utils.hpp
@@ -14,11 +14,12 @@
 #include <algorithm>
 #include <iterator>
 #include <stdint.h>
+#include "psram-allocator.hpp"
 #include "xoshiro256.hpp"
 
 namespace ur {
 
-typedef std::set<size_t> PartIndexes;
+typedef std::set<size_t, std::less<size_t>, PSRAMAllocator<size_t>> PartIndexes;
 
 // Fisher-Yates shuffle
 template<typename T>
@@ -35,26 +36,26 @@ std::vector<T> shuffled(const std::vector<T>& items, Xoshiro256& rng) {
 }
 
 // Return `true` if `a` is a strict subset of `b`.
-template<typename T>
-bool is_strict_subset(const std::set<T>& a, const std::set<T>& b) {
+template<typename T, typename C, typename A>
+bool is_strict_subset(const std::set<T, C, A>& a, const std::set<T, C, A>& b) {
     if(a == b) { return false; }
     return std::includes(b.begin(), b.end(), a.begin(), a.end());
 }
 
-template<typename T>
-std::set<T> set_difference(const std::set<T>& a, const std::set<T>& b) {
-    std::set<T> result;
+template<typename T, typename C, typename A>
+std::set<T, C, A> set_difference(const std::set<T, C, A>& a, const std::set<T, C, A>& b) {
+    std::set<T, C, A> result;
     std::set_difference(a.begin(), a.end(), b.begin(), b.end(), std::inserter(result, result.begin()));
     return result;
 }
 
-template<typename T>
-bool contains(const std::set<T>& s, const T& v) {
+template<typename T, typename C, typename A>
+bool contains(const std::set<T, C, A>& s, const T& v) {
     return s.find(v) != s.end();
 }
 
 size_t choose_degree(size_t seq_len, Xoshiro256& rng);
-std::set<size_t> choose_fragments(uint32_t seq_num, size_t seq_len, uint32_t checksum);
+PartIndexes choose_fragments(uint32_t seq_num, size_t seq_len, uint32_t checksum);
 
 }
 

--- a/src/psram-allocator.hpp
+++ b/src/psram-allocator.hpp
@@ -1,0 +1,45 @@
+#ifndef BC_UR_PSRAM_ALLOCATOR_HPP
+#define BC_UR_PSRAM_ALLOCATOR_HPP
+
+//
+//  psram-allocator.hpp
+//
+//  Minimal std::allocator type that prefers SPI/PS-RAM if it is available.
+//
+
+#include <cstdlib>
+#include <memory>
+
+#include <esp_heap_caps.h>
+
+template <typename T>
+class PSRAMAllocator {
+public:
+    using value_type = T;
+
+    PSRAMAllocator() noexcept = default;
+
+    template <typename U>
+    PSRAMAllocator(const PSRAMAllocator<U>& other) noexcept {};
+
+    T* allocate(std::size_t n) {
+      const size_t size = n * sizeof(T);
+      return static_cast<T*>(heap_caps_malloc_prefer(size, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT));
+    }
+
+    void deallocate(T* ptr, std::size_t n) noexcept {
+      std::free(ptr);
+    }
+};
+
+template <typename T, typename U>
+bool operator==(const PSRAMAllocator<T>&, const PSRAMAllocator<U>&) {
+    return true;
+}
+
+template <typename T, typename U>
+bool operator!=(const PSRAMAllocator<T>& lhs, const PSRAMAllocator<U>& rhs) {
+    return !(lhs == rhs);
+}
+
+#endif

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -15,10 +15,13 @@
 #include <array>
 #include <assert.h>
 
+#include "psram-allocator.hpp"
+
 namespace ur {
 
-typedef std::vector<uint8_t> ByteVector;
-typedef std::vector<std::string> StringVector;
+typedef std::vector<uint8_t, PSRAMAllocator<uint8_t>> ByteVector;
+typedef std::vector<ByteVector, PSRAMAllocator<ByteVector>> ByteVectorVector;
+typedef std::vector<std::string, PSRAMAllocator<std::string>> StringVector;
 
 ByteVector sha256(const ByteVector &buf);
 ByteVector crc32_bytes(const ByteVector &buf);
@@ -40,39 +43,39 @@ StringVector partition(const std::string& string, size_t size);
 std::string take_first(const std::string &s, size_t count);
 std::string drop_first(const std::string &s, size_t count);
 
-template<typename T>
-void append(std::vector<T>& target, const std::vector<T>& source) {
+template<typename T, typename A>
+void append(std::vector<T, A>& target, const std::vector<T, A>& source) {
     target.insert(target.end(), source.begin(), source.end());
 }
 
-template<typename T, size_t N>
-void append(std::vector<T>& target, const std::array<T, N>& source) {
+template<typename T, typename A, size_t N>
+void append(std::vector<T, A>& target, const std::array<T, N>& source) {
     target.insert(target.end(), source.begin(), source.end());
 }
 
-template<typename T>
-std::vector<T> join(const std::vector<std::vector<T>>& parts) {
-    std::vector<T> result;
+template<typename T, typename A1, typename A2>
+std::vector<T, A1> join(const std::vector<std::vector<T, A1>, A2>& parts) {
+    std::vector<T, A1> result;
     for(auto part: parts) { append(result, part); }
     return result;
 }
 
-template<typename T>
-std::pair<std::vector<T>, std::vector<T>> split(const std::vector<T>& buf, size_t count) {
+template<typename T, typename A>
+std::pair<std::vector<T, A>, std::vector<T, A>> split(const std::vector<T, A>& buf, size_t count) {
     auto first = buf.begin();
     auto c = std::min(buf.size(), count);
     auto last = first + c;
-    auto a = std::vector(first, last);
-    auto b = std::vector(last, buf.end());
+    auto a = std::vector<T, A>(first, last);
+    auto b = std::vector<T, A>(last, buf.end());
     return std::make_pair(a, b);
 }
 
-template<typename T>
-std::vector<T> take_first(const std::vector<T> &buf, size_t count) {
+template<typename T, typename A>
+std::vector<T, A> take_first(const std::vector<T, A> &buf, size_t count) {
     auto first = buf.begin();
     auto c = std::min(buf.size(), count);
     auto last = first + c;
-    return std::vector(first, last);
+    return std::vector<T, A>(first, last);
 }
 
 void xor_into(ByteVector& target, const ByteVector& source);


### PR DESCRIPTION
This change is to implement and use a std::allocator<> during decoding which prefers SPI-connected PSRAM when available, so the fragment data is stored in the much larger PSRAM from the outset (rather than using available DRAM first).
Fixes issues which can otherwise be caused for other tasks/processes (which may require DRAM) when a large number of data fragments are being decoded (ie. when a large payload has been encoded into a large number of fragments).