### PR TITLE
esp32-build: improve setting cpp-17 compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(SRC_DIRS "src"
         PRIV_REQUIRES mbedtls cbor
         INCLUDE_DIRS "src")
 
-component_compile_options(-std=c++17)
+target_compile_features(${COMPONENT_LIB} PRIVATE cxx_std_17)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Ofast)


### PR DESCRIPTION
Fixes compilation warnings when inappropriate flag applied to C files.